### PR TITLE
Send heartbeats but don't wait to receive ones

### DIFF
--- a/tinytuya/__init__.py
+++ b/tinytuya/__init__.py
@@ -234,11 +234,11 @@ async def heartbeat(device, haobj):
         else:
             await asyncio.sleep(10)
 
-        log.debug("[" + devid + "] " + str(device.heartbeatssend) + " heartbeats send, " + str(device.heartbeatsreceived) + " heartbeats received")        
-        if(device.heartbeatsreceived < device.heartbeatssend and device.device.get_version() != 3.4):
-            device.device.close()
-            if(device.listener != None):
-                device.listener.disconnected()
+        # log.debug("[" + devid + "] " + str(device.heartbeatssend) + " heartbeats send, " + str(device.heartbeatsreceived) + " heartbeats received")        
+        # if(device.heartbeatsreceived < device.heartbeatssend and device.device.get_version() != 3.4):
+        #     device.device.close()
+        #     if(device.listener != None):
+        #         device.listener.disconnected()
 
 
 


### PR DESCRIPTION
I have tested with my 3.3 devices and they never send back heartbeats. The examples in the tinytuya project don't wait for heartbeat response as well. With this change 3.3 devices are working as well.